### PR TITLE
Fix invalid state not being reported in exception

### DIFF
--- a/airflow_provider_hightouch/hooks/hightouch.py
+++ b/airflow_provider_hightouch/hooks/hightouch.py
@@ -117,7 +117,7 @@ class HightouchHook(HttpHook):
             if state == self.SUCCESS:
                 break
 
-            raise AirflowException("Unhandled state: {state}")
+            raise AirflowException(f"Unhandled state: {state}")
 
     def submit_sync(
         self,

--- a/tests/hooks/test_hightouch_hook.py
+++ b/tests/hooks/test_hightouch_hook.py
@@ -94,7 +94,7 @@ class TestHightouchHook(unittest.TestCase):
         hook = HightouchHook()
         with pytest.raises(AirflowException) as excinfo:
             hook.poll(sync_id=1, wait_seconds=1, timeout=5, error_on_warning=True)
-            assert "Job 1 failed to complete with status warning" in str(excinfo.value)
+        assert "Job 1 failed to complete with status warning" in str(excinfo.value)
 
     @requests_mock.mock()
     def test_poll_success_ignore_warning(self, requests_mock):
@@ -114,7 +114,18 @@ class TestHightouchHook(unittest.TestCase):
         hook = HightouchHook()
         with pytest.raises(AirflowException) as excinfo:
             hook.poll(sync_id=1, wait_seconds=0.11, timeout=5, error_on_warning=True)
-            assert "Job 1 failed to complete with status failed" in str(excinfo.value)
+        assert "Job 1 failed to complete with status failed" in str(excinfo.value)
+
+    @requests_mock.mock()
+    def test_poll_invalid_status(self, requests_mock):
+        requests_mock.get(
+            "https://test.hightouch.io/api/v2/rest/sync/1",
+            json=payload_factory("invalid_status"),
+        )
+        hook = HightouchHook()
+        with pytest.raises(AirflowException) as excinfo:
+            hook.poll(sync_id=1, wait_seconds=0.11, timeout=5, error_on_warning=True)
+        assert "Unhandled state: invalid_status" in str(excinfo.value)
 
     @requests_mock.mock()
     def test_poll_pending_then_complete(self, requests_mock):
@@ -141,9 +152,9 @@ class TestHightouchHook(unittest.TestCase):
         hook = HightouchHook()
         with pytest.raises(AirflowException) as excinfo:
             hook.poll(sync_id=1, wait_seconds=0.5, timeout=1, error_on_warning=True)
-            assert "Timeout: Hightouch job 1 was not ready after 1 seconds." in str(
-                excinfo.value
-            )
+        assert "Timeout: Hightouch job 1 was not ready after 1 seconds." in str(
+            excinfo.value
+        )
 
     @requests_mock.mock()
     def test_poll_no_last_sync_run_retries(self, requests_mock):


### PR DESCRIPTION
We were seeing an error in our airflow operator where it would report an invalid state but it would not tell us what it was due to a missing `f` in the string:

```
  File "/usr/local/autotrader/lib/python3.8/site-packages/airflow_provider_hightouch/hooks/hightouch.py", line 108, in poll
    raise AirflowException("Unhandled state: {state}")
airflow.exceptions.AirflowException: Unhandled state: {state}
```

Also I noticed when writing the unit test that the `assert` statements were not being executed when placed inside the context manager `pytest.raises`. Pulling these out the context manager ensures the tests actually check the exception's message.