### PR TITLE
timeout test with dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM python:3.9
+
+COPY . .
+
+# this project doesnt have a requirements.txt :sigh:
+RUN python -m pip install --upgrade pip
+RUN pip3 install -e .
+RUN pip3 install requests
+RUN pip3 install apache-airflow
+RUN pip3 install pytest
+RUN pip3 install requests_mock
+
+CMD python -m unittest discover
+
+# docker build -t "htairflow:latest" .
+# docker run htairflow

--- a/airflow_provider_hightouch/operators/hightouch.py
+++ b/airflow_provider_hightouch/operators/hightouch.py
@@ -53,7 +53,7 @@ class HightouchTriggerSyncOperator(BaseOperator):
         synchronous: bool = True,
         error_on_warning: bool = False,
         wait_seconds: float = 3,
-        timeout: int = 3600,
+        timeout: int = 5,
         **kwargs,
     ):
         super().__init__(**kwargs)

--- a/tests/operators/test_hightouch_operator.py
+++ b/tests/operators/test_hightouch_operator.py
@@ -34,7 +34,7 @@ class TestHightouchOperator(unittest.TestCase):
                         "createdAt": "2022-02-08T16:11:04.712Z",
                         "finishedAt": "2022-02-08T16:11:11.698Z",
                         "querySize": 773,
-                        "status": "success",
+                        "status": "pending",
                         "completionRatio": 0.54,
                         "plannedRows": {
                             "addedCount": 773,
@@ -121,6 +121,6 @@ class TestHightouchOperator(unittest.TestCase):
             "https://test.hightouch.io/api/v1/syncs/trigger",
             json={"id": "123"},
         )
-        operator = HightouchTriggerSyncOperator(task_id="run", sync_id=1)
+        operator = HightouchTriggerSyncOperator(task_id="run", sync_id=1, timeout=10);
 
         operator.execute(context={})


### PR DESCRIPTION
CS ticket came in reporting that 
```
trigger_sync = HightouchTriggerSyncOperator(
task_id=f"{name}_sync",
connection_id="hightouch",
sync_id=sync_id,
synchronous=True,
error_on_warning=False,
timeout=60*60*3,
)
```
was still timing out after only `60*60` instead of `60*60*30`.

So I modified a test case to simulate a pending sync + a timeout.

10 second timeout working as expected (it raises after about 10 seconds).
```
nickstefan@Nicks-MacBook-Pro airflow-provider-hightouch % docker run htairflow
/airflow_provider_hightouch/operators/hightouch.py:18 RemovedInAirflow3Warning: This decorator is deprecated.

In previous versions, all subclasses of BaseOperator must use apply_default decorator for the `default_args` feature to work properly.

In current version, it is optional. The decorator is applied automatically using the metaclass.

[2022-11-15 16:42:09,120] {base.py:71} INFO - Using connection ID 'hightouch_default' for task execution.
[2022-11-15 16:42:09,120] {base.py:71} INFO - Using connection ID 'hightouch_default' for task execution.
[2022-11-15 16:42:09,121] {http.py:148} INFO - Sending 'GET' to url: https://test.hightouch.io/api/v1/syncs/1
.[2022-11-15 16:42:09,122] {base.py:71} INFO - Using connection ID 'hightouch_default' for task execution.
[2022-11-15 16:42:09,122] {base.py:71} INFO - Using connection ID 'hightouch_default' for task execution.
[2022-11-15 16:42:09,123] {http.py:148} INFO - Sending 'POST' to url: https://test.hightouch.io/api/v1/syncs/trigger
.[2022-11-15 16:42:09,123] {base.py:71} INFO - Using connection ID 'hightouch_default' for task execution.
[2022-11-15 16:42:09,123] {base.py:71} INFO - Using connection ID 'hightouch_default' for task execution.
[2022-11-15 16:42:09,124] {http.py:148} INFO - Sending 'POST' to url: https://test.hightouch.io/api/v1/syncs/trigger
.[2022-11-15 16:42:09,124] {hightouch.py:82} INFO - Start synchronous request to run a sync.
[2022-11-15 16:42:09,125] {base.py:71} INFO - Using connection ID 'hightouch_default' for task execution.
[2022-11-15 16:42:09,125] {base.py:71} INFO - Using connection ID 'hightouch_default' for task execution.
[2022-11-15 16:42:09,125] {http.py:148} INFO - Sending 'POST' to url: https://test.hightouch.io/api/v1/syncs/trigger
[2022-11-15 16:42:09,125] {base.py:71} INFO - Using connection ID 'hightouch_default' for task execution.
[2022-11-15 16:42:09,126] {base.py:71} INFO - Using connection ID 'hightouch_default' for task execution.
[2022-11-15 16:42:09,126] {http.py:148} INFO - Sending 'GET' to url: https://test.hightouch.io/api/v1/syncs/1/runs
[2022-11-15 16:42:09,126] {hightouch.py:186} INFO - Polling Hightouch Sync 1. Current status: pending. 54.0% completed.
[2022-11-15 16:42:12,131] {base.py:71} INFO - Using connection ID 'hightouch_default' for task execution.
[2022-11-15 16:42:12,138] {base.py:71} INFO - Using connection ID 'hightouch_default' for task execution.
[2022-11-15 16:42:12,142] {http.py:148} INFO - Sending 'GET' to url: https://test.hightouch.io/api/v1/syncs/1/runs
[2022-11-15 16:42:12,145] {hightouch.py:186} INFO - Polling Hightouch Sync 1. Current status: pending. 54.0% completed.
[2022-11-15 16:42:15,149] {base.py:71} INFO - Using connection ID 'hightouch_default' for task execution.
[2022-11-15 16:42:15,151] {base.py:71} INFO - Using connection ID 'hightouch_default' for task execution.
[2022-11-15 16:42:15,153] {http.py:148} INFO - Sending 'GET' to url: https://test.hightouch.io/api/v1/syncs/1/runs
[2022-11-15 16:42:15,159] {hightouch.py:186} INFO - Polling Hightouch Sync 1. Current status: pending. 54.0% completed.
[2022-11-15 16:42:18,166] {base.py:71} INFO - Using connection ID 'hightouch_default' for task execution.
[2022-11-15 16:42:18,168] {base.py:71} INFO - Using connection ID 'hightouch_default' for task execution.
[2022-11-15 16:42:18,170] {http.py:148} INFO - Sending 'GET' to url: https://test.hightouch.io/api/v1/syncs/1/runs
[2022-11-15 16:42:18,177] {hightouch.py:186} INFO - Polling Hightouch Sync 1. Current status: pending. 54.0% completed.
[2022-11-15 16:42:21,182] {base.py:71} INFO - Using connection ID 'hightouch_default' for task execution.
[2022-11-15 16:42:21,184] {base.py:71} INFO - Using connection ID 'hightouch_default' for task execution.
[2022-11-15 16:42:21,186] {http.py:148} INFO - Sending 'GET' to url: https://test.hightouch.io/api/v1/syncs/1/runs
[2022-11-15 16:42:21,195] {hightouch.py:186} INFO - Polling Hightouch Sync 1. Current status: pending. 54.0% completed.
E
======================================================================
ERROR: test_hightouch_operator (tests.operators.test_hightouch_operator.TestHightouchOperator)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/local/lib/python3.9/unittest/mock.py", line 1768, in _inner
    return f(*args, **kw)
  File "/usr/local/lib/python3.9/site-packages/requests_mock/mocker.py", line 317, in inner
    return func(*args, **kwargs)
  File "/tests/operators/test_hightouch_operator.py", line 126, in test_hightouch_operator
    operator.execute(context={})
  File "/airflow_provider_hightouch/operators/hightouch.py", line 83, in execute
    hightouch_output = hook.sync_and_poll(
  File "/airflow_provider_hightouch/hooks/hightouch.py", line 255, in sync_and_poll
    ht_output = self.poll_sync(
  File "/airflow_provider_hightouch/hooks/hightouch.py", line 217, in poll_sync
    raise AirflowException(
airflow.exceptions.AirflowException: Sync 1 for request: 123' time out after 0:00:12.070375. Last status was pending.

----------------------------------------------------------------------
Ran 4 tests in 12.170s

FAILED (errors=1)
```
