### PR TITLE
Remove apply_default decorator from operator

### DIFF
--- a/airflow_provider_hightouch/operators/hightouch.py
+++ b/airflow_provider_hightouch/operators/hightouch.py
@@ -43,7 +43,6 @@ class HightouchTriggerSyncOperator(BaseOperator):
 
     operator_extra_links = (HightouchLink(),)
 
-    @apply_defaults
     def __init__(
         self,
         sync_id: Optional[str] = None,


### PR DESCRIPTION
The decorator gives deprecation warning (using airflow 2.5.1)

```
<PYTHON ENV PATH>/lib/python3.8/site-packages/airflow_provider_hightouch/operators/hightouch.py:18: RemovedInAirflow3Warning: This decorator is deprecated.

  In previous versions, all subclasses of BaseOperator must use apply_default decorator for the `default_args` feature to work properly.

  In current version, it is optional. The decorator is applied automatically using the metaclass.
```