### PR TITLE
add extra sleep time for 429

### DIFF
--- a/airflow_provider_hightouch/hooks/hightouch.py
+++ b/airflow_provider_hightouch/hooks/hightouch.py
@@ -40,7 +40,7 @@ class HightouchHook(HttpHook):
         api_version: str = "v3",
         request_max_retries: int = 3,
         request_retry_delay: float = 0.5,
-        request_backoff_factor: float = 5.0
+        request_backoff_factor: float = 10.0
     ):
         self.hightouch_conn_id = hightouch_conn_id
         self.api_version = api_version
@@ -102,7 +102,7 @@ class HightouchHook(HttpHook):
                     break
                 num_retries += 1
                 if "429" in str(e):
-                    backoff_delay = self._request_backoff_factor * (2 ** (num_retries + 1))
+                    backoff_delay = self._request_backoff_factor * (2 ** (num_retries - 1))
                     time.sleep(backoff_delay)
                 else:
                     time.sleep(self._request_retry_delay)

--- a/airflow_provider_hightouch/hooks/hightouch.py
+++ b/airflow_provider_hightouch/hooks/hightouch.py
@@ -98,7 +98,10 @@ class HightouchHook(HttpHook):
                 if num_retries == self._request_max_retries:
                     break
                 num_retries += 1
-                time.sleep(self._request_retry_delay)
+                if "429" in str(e):
+                    time.sleep(10)
+                else:
+                    time.sleep(self._request_retry_delay)
 
         raise AirflowException("Exceeded max number of retries.")
 


### PR DESCRIPTION
This adds an exponential backoff to retry calls in the event of a 429 in line with throttle limits by Hightouch. It might be worth it to change this for all retries, and maybe pull this into a util.