### PR TITLE
Add deferrable sync operator

### DIFF
--- a/airflow_provider_hightouch/operators/hightouch_deferrable.py
+++ b/airflow_provider_hightouch/operators/hightouch_deferrable.py
@@ -1,0 +1,121 @@
+from typing import Optional
+
+from airflow.exceptions import AirflowException
+from airflow.models import BaseOperator
+from airflow.utils.context import Context
+from airflow_provider_hightouch.hooks.hightouch import HightouchHook  # type: ignore
+from airflow_provider_hightouch.triggers import HightouchTrigger
+
+
+class HightouchDeferrableSyncOperator(BaseOperator):
+    """
+    Deferable version of HightouchDeferrableSyncOperator.
+
+    This operator triggers a Hightouch sync and defers execution until the sync is completed.
+    """
+
+    def __init__(
+        self,
+        workspace_id: Optional[str],
+        sync_id: Optional[str] = None,
+        sync_slug: Optional[str] = None,
+        connection_id: str = "hightouch_default",
+        api_version: str = "v3",
+        error_on_warning: bool = False,
+        poll_interval: float = 15,
+        timeout: int = 3600,
+        **kwargs,
+    ):
+        """
+        Initializes the HightouchDeferrableSyncOperator.
+
+        Args:
+            workspace_id (Optional[str]): The Hightouch workspace_id.
+            sync_id (Optional[str]): The ID of the sync to trigger.
+            sync_slug (Optional[str]): The slug of the sync to trigger.
+            connection_id (str): The connection ID for Hightouch.
+            api_version (str): The API version to use.
+            error_on_warning (bool): If True, raise an error on warnings.
+            poll_interval (float): The interval to poll for sync completion.
+            timeout (int): The maximum time to wait for the sync to complete.
+            **kwargs: Additional keyword arguments.
+        """
+        super().__init__(**kwargs)
+        self.hightouch_conn_id = connection_id
+        self.api_version = api_version
+        self.sync_id = sync_id
+        self.sync_slug = sync_slug
+        self.workspace_id = workspace_id
+        self.error_on_warning = error_on_warning
+        self.poll_interval = poll_interval
+        self.timeout = timeout
+
+    def execute(self, context: Context):
+        """
+        Starts the Hightouch sync and defers execution.
+
+        This method triggers the Hightouch sync asynchronously and defers execution
+        until the sync is completed. It requires either a sync_id or sync_slug to
+        initiate the sync process.
+
+        Args:
+            context (Context): The context in which the operator is executed.
+
+        Raises:
+            AirflowException: If neither sync_id nor sync_slug is provided, or if both are provided.
+        """
+        hook = HightouchHook(hightouch_conn_id=self.hightouch_conn_id)
+
+        # Validate that exactly one of sync_id or sync_slug is provided
+        if (self.sync_id is None) == (self.sync_slug is None):
+            raise AirflowException("Exactly one of sync_id or sync_slug must be provided.")
+
+        if self.sync_slug:
+            self.log.info(f"Triggering sync asynchronously using slug ID: {self.sync_slug}...")
+
+            sync_request_id = hook.start_sync(sync_slug=self.sync_slug)
+            self.sync_id = hook.get_sync_from_slug(sync_slug=self.sync_slug)  # Retrieve sync_id based on slug
+        else:
+            self.log.info(f"Triggering sync asynchronously using sync ID: {self.sync_id}...")
+            sync_request_id = hook.start_sync(sync_id=self.sync_id)
+
+        self.log.info(f"Successfully started sync {self.sync_id}. Deferring execution...")
+
+        self.defer(
+            trigger=HightouchTrigger(
+                workspace_id=self.workspace_id,
+                sync_id=self.sync_id,
+                sync_request_id=sync_request_id,
+                sync_slug=self.sync_slug,
+                connection_id=self.hightouch_conn_id,
+                poll_interval=self.poll_interval,
+                timeout=self.timeout,
+            ),
+            method_name="execute_complete",
+        )
+
+    def execute_complete(self, context: Context, event: dict):
+        """
+        Resumes execution after the trigger completes.
+
+        This method is called after the Hightouch sync completes. It processes the
+        event containing the sync status and raises exceptions if the sync fails or
+        times out.
+
+        Args:
+            context (Context): The context in which the operator is executed.
+            event (dict): The event containing the sync status.
+
+        Raises:
+            AirflowException: If the sync fails or times out.
+        """
+        status = event.get("status")
+        message = event.get("message")
+
+        if status == "success":
+            self.log.info(message)
+            return event.get("sync_id", None)
+        elif status in ["failed", "timeout"]:
+            raise AirflowException(message)
+        else:
+            raise AirflowException(message)

--- a/airflow_provider_hightouch/operators/hightouch_deferrable.py
+++ b/airflow_provider_hightouch/operators/hightouch_deferrable.py
@@ -72,9 +72,8 @@ class HightouchDeferrableSyncOperator(BaseOperator):
 
         if self.sync_slug:
             self.log.info(f"Triggering sync asynchronously using slug ID: {self.sync_slug}...")
-
             sync_request_id = hook.start_sync(sync_slug=self.sync_slug)
-            self.sync_id = hook.get_sync_from_slug(sync_slug=self.sync_slug)  # Retrieve sync_id based on slug
+            self.sync_id = hook.get_sync_from_slug(sync_slug=self.sync_slug)
         else:
             self.log.info(f"Triggering sync asynchronously using sync ID: {self.sync_id}...")
             sync_request_id = hook.start_sync(sync_id=self.sync_id)

--- a/airflow_provider_hightouch/triggers/hightouch_trigger.py
+++ b/airflow_provider_hightouch/triggers/hightouch_trigger.py
@@ -1,5 +1,5 @@
 import asyncio
-import os
+
 from typing import Any, AsyncIterator, Dict, Optional, Tuple
 
 from airflow.triggers.base import BaseTrigger, TriggerEvent

--- a/airflow_provider_hightouch/triggers/hightouch_trigger.py
+++ b/airflow_provider_hightouch/triggers/hightouch_trigger.py
@@ -1,0 +1,150 @@
+import asyncio
+import os
+from typing import Any, AsyncIterator, Dict, Optional, Tuple
+
+from airflow.triggers.base import BaseTrigger, TriggerEvent
+from airflow_provider_hightouch.hooks.hightouch import HightouchHook  # type: ignore
+
+
+class HightouchTrigger(BaseTrigger):
+    """
+    Trigger to monitor a Hightouch sync run asynchronously.
+
+    This trigger checks the status of a Hightouch sync run at regular intervals
+    until it completes, fails, or times out. It uses the Hightouch API to retrieve
+    the sync status and yields events based on the sync's progress.
+
+    Args:
+        workspace_id (str): The Hightouch workspace_id.
+        sync_id (str): The ID of the Hightouch sync.
+        sync_request_id (str): The request ID of the sync run to monitor.
+        sync_slug (str): The slug of the Hightouch sync.
+        connection_id (str): The Airflow connection ID for Hightouch API access.
+        timeout (float): The maximum time (in seconds) to wait before timing out.
+        poll_interval (float): The time (in seconds) to wait between status checks.
+    """
+
+    def __init__(
+        self,
+        workspace_id: Optional[str],
+        sync_id: Optional[str],
+        sync_request_id: str,
+        sync_slug: Optional[str],
+        connection_id: str,
+        timeout: float,
+        poll_interval: float = 4.0,
+    ) -> None:
+        """
+        Initializes the HightouchTrigger with the provided parameters.
+
+        Args:
+            workspace_id (str): The Hightouch workspace_id.
+            sync_id (str): The ID of the Hightouch sync.
+            sync_request_id (str): The request ID of the sync run to monitor.
+            sync_slug (str): The slug of the Hightouch sync.
+            connection_id (str): The Airflow connection ID for Hightouch API access.
+            timeout (float): The maximum time (in seconds) to wait before timing out.
+            poll_interval (float): The time (in seconds) to wait between status checks.
+        """
+        super().__init__()
+        self.workspace_id = workspace_id
+        self.sync_id = sync_id
+        self.sync_request_id = sync_request_id
+        self.sync_slug = sync_slug
+        self.connection_id = connection_id
+        self.poll_interval = poll_interval
+        self.timeout = timeout
+        self.hook = HightouchHook(hightouch_conn_id=self.connection_id)
+
+    def serialize(self) -> Tuple[str, Dict[str, Any]]:
+        """
+        Serialize the trigger state for storage.
+
+        Returns:
+            Tuple[str, Dict[str, Any]]: A tuple containing the fully qualified class name
+            and a dictionary of the trigger's parameters for state restoration.
+        """
+        return (
+            f"{self.__module__}.{self.__class__.__name__}",
+            {
+                "sync_id": self.sync_id,
+                "sync_request_id": self.sync_request_id,
+                "sync_slug": self.sync_slug,
+                "connection_id": self.connection_id,
+                "poll_interval": self.poll_interval,
+                "timeout": self.timeout,
+                "workspace_id": self.workspace_id
+            },
+        )
+
+    async def run(self) -> AsyncIterator[TriggerEvent]:
+        """
+        Periodically checks the sync status until completion or timeout.
+
+        This method uses the Hightouch API to check the status of a sync run at
+        regular intervals defined by the poll_interval. It yields TriggerEvents
+        based on the current status of the sync.
+
+        Yields:
+            AsyncIterator[TriggerEvent]: Events indicating the status of the sync run,
+            which can be "success", "failed", "timeout", or the current status during polling.
+        """
+        start_time = asyncio.get_event_loop().time()
+        full_url = f"https://app.hightouch.com/{self.workspace_id}/syncs/{self.sync_id}/runs/{self.sync_request_id}"
+
+        while True:
+
+            try:
+                # Fetch the current sync status
+                response = self.hook.get_sync_run_details(
+                    self.sync_id, self.sync_request_id
+                )[0]
+
+                status = response["status"]
+
+                # Handle different sync statuses
+                if status in ["success", "completed"]:
+                    yield TriggerEvent(
+                        {
+                            "status": status,
+                            "sync_id": self.sync_id,
+                            "message": f"{full_url} finished with status {status}!",
+                        }
+                    )
+                    return
+
+                elif status in ["queued", "processing", "querying"]:
+                    self.log.info(
+                        f"Sync is {status}... Sleeping for {self.poll_interval} seconds."
+                    )
+                    await asyncio.sleep(self.poll_interval)
+
+                elif status in ["failed", "error"]:
+                    yield TriggerEvent(
+                        {
+                            "status": status,
+                            "message": f"{full_url} finished with status {status}!\n"
+                            f"Sync Error: {response['error']}",
+                        }
+                    )
+                    return
+
+                # Check for timeout
+                if asyncio.get_event_loop().time() - start_time > self.timeout:
+                    yield TriggerEvent(
+                        {
+                            "status": "timeout",
+                            "message": f"{full_url} exceeded DAG timeout of {self.timeout} seconds.",
+                        }
+                    )
+                    return
+
+            except Exception as e:
+                self.log.error("Error while checking sync status: %s", str(e))
+                yield TriggerEvent(
+                    {
+                        "status": status,
+                        "message": str(e),
+                    }
+                )
+                return


### PR DESCRIPTION
### Pull Request Description: Hightouch Deferrable Sync Operator

#### Overview
This pull request introduces the `HightouchDeferrableSyncOperator` and `HightouchTrigger` for asynchronous management of Hightouch sync operations in Airflow using deferrable operator framework: https://airflow.apache.org/docs/apache-airflow/stable/authoring-and-scheduling/deferring.html#writing-deferrable-operators

#### Key Changes
1. **HightouchDeferrableSyncOperator**:
   - Triggers a Hightouch sync and defers execution until completion.
   - Requires either a `sync_id` or `sync_slug` and raises exceptions for invalid inputs.
   - Uses `HightouchHook` for API interactions and supports configurable polling and timeout settings.

2. **HightouchTrigger**:
   - Monitors the sync status asynchronously, yielding events based on the sync's progress (success, failure, timeout).
   - Includes error handling and logging for better diagnostics.

#### Testing
- Successfully tested in a local Astronomer instance, validating all features and error handling.

#### Benefits
- **Efficiency**: Optimizes resource usage by deferring execution.
- **Flexibility**: Allows initiation of syncs via `sync_id` or `sync_slug`.
- **Robustness**: Enhanced error handling and logging capabilities.