### PR TITLE
Add `sync_run_id` as template field to `HightouchSyncRunSensor`

### DIFF
--- a/airflow_provider_hightouch/sensors/hightouch.py
+++ b/airflow_provider_hightouch/sensors/hightouch.py
@@ -40,6 +40,7 @@ class HightouchSyncRunSensor(BaseSensorOperator):
     """
 
     operator_extra_links = (HightouchLink(),)
+    template_fields = ["sync_run_id"]
 
     @apply_defaults
     def __init__(


### PR DESCRIPTION

When `sync_run_id` is not a template field, it cannot be used as the return value from `HightouchTriggerSyncOperator`. 

Below xcom does not work currently 
```python
            run_sync = HightouchTriggerSyncOperator(
                task_id=f"run_sync",
                sync_id=sync_id,
                synchronous=False,
            )

            wait_for_sync_end = HightouchSyncRunSensor(
                task_id=f"wait_for_sync", 
                sync_run_id="{{ ti.xcom_pull(task_ids = 'run_sync') }}",
                sync_id=sync_id,
            )
```

and gives the following error:

```
{http.py:154} ERROR - HTTP error: Unprocessable Entity
{http.py:155} ERROR - {"message":"Validation Failed","details":{"runId":{"message":"invalid float number","value":"{{ ti.xcom_pull(task_ids = 'run_sync') }}"}}}
```