### PR TITLE
Add support for Apache Airflow 3.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 4.0.1
+
+### Fixes:
+
+- Added compatibility with Apache Airflow 3.x.x
+
 ## 4.0.0
 
 - Introduces HightouchSyncRunSensor, which monitors the success or failure of a sync run

--- a/airflow_provider_hightouch/operators/hightouch.py
+++ b/airflow_provider_hightouch/operators/hightouch.py
@@ -2,7 +2,7 @@ from typing import Optional
 
 from airflow.exceptions import AirflowException
 from airflow.models import BaseOperator, BaseOperatorLink
-from airflow.utils.decorators import apply_defaults
+from airflow.models.taskinstancekey import TaskInstanceKey
 
 from airflow_provider_hightouch.hooks.hightouch import HightouchHook
 from airflow_provider_hightouch.utils import parse_sync_run_details
@@ -11,7 +11,7 @@ from airflow_provider_hightouch.utils import parse_sync_run_details
 class HightouchLink(BaseOperatorLink):
     name = "Hightouch"
 
-    def get_link(self, operator, dttm):
+    def get_link(self, operator: BaseOperator, *, ti_key: TaskInstanceKey):
         return "https://app.hightouch.io"
 
 
@@ -43,7 +43,6 @@ class HightouchTriggerSyncOperator(BaseOperator):
 
     operator_extra_links = (HightouchLink(),)
 
-    @apply_defaults
     def __init__(
         self,
         sync_id: Optional[str] = None,

--- a/airflow_provider_hightouch/sensors/hightouch.py
+++ b/airflow_provider_hightouch/sensors/hightouch.py
@@ -1,10 +1,10 @@
 from typing import Optional
 
-from airflow.models.baseoperator import BaseOperatorLink
+from airflow.models.baseoperator import BaseOperator, BaseOperatorLink
+from airflow.models.taskinstancekey import TaskInstanceKey
 from airflow.sensors.base import BaseSensorOperator
 
 from airflow.exceptions import AirflowException
-from airflow.utils.decorators import apply_defaults
 
 from airflow_provider_hightouch.hooks.hightouch import HightouchHook
 from airflow_provider_hightouch.utils import parse_sync_run_details
@@ -15,7 +15,7 @@ from airflow_provider_hightouch.consts import *
 class HightouchLink(BaseOperatorLink):
     name = "Hightouch"
 
-    def get_link(self, operator, dttm):
+    def get_link(self, operator: BaseOperator, *, ti_key: TaskInstanceKey):
         return "https://app.hightouch.io"
 
 
@@ -41,7 +41,6 @@ class HightouchSyncRunSensor(BaseSensorOperator):
 
     operator_extra_links = (HightouchLink(),)
 
-    @apply_defaults
     def __init__(
         self,
         sync_run_id: str,

--- a/airflow_provider_hightouch/version.py
+++ b/airflow_provider_hightouch/version.py
@@ -1,7 +1,7 @@
 import os
 import sys
 
-__version__ = "4.0.0"
+__version__ = "4.0.1"
 
 
 def validate_version():


### PR DESCRIPTION
## Overview

This PR adds support for `apache-airflow==3.0.4`, which package version 4.0.0 is currently not compatible with. Related to: #29 

## Changes

- Modified the HightouchTriggerSyncOperator's `get_link()` arguments, following [this documentation](https://airflow.apache.org/docs/apache-airflow/stable/howto/define-extra-link.html).
- Removed `apply_defaults` decorator, which has been deprecated for a while (see #18) but only got removed in Airflow 3.
- Bumped package version from 4.0.0 to 4.0.1, added notes to changelog.

## Additional

On top of my own testing using Airflow 3, `pytest` tests have all passed with both `apache-airflow==3.0.4` and `apache-airflow==2.10.3`, so I am fairly certain package 4.0.1 is still compatible with Airflow 2.x.x.